### PR TITLE
Fix crash on linux with window managers & some refactor

### DIFF
--- a/src/useful_tools.rs
+++ b/src/useful_tools.rs
@@ -36,7 +36,10 @@ pub fn osAndDesktopEnvironment() -> (String, Option<String>) {
     #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
     {
         let os_type = "Linux".to_string();
-        let desktop_env = Some(env::var("XDG_CURRENT_DESKTOP").unwrap());
+        let desktop_env = match env::var("XDG_CURRENT_DESKTOP") {
+            Ok(val) => Some(val),
+            Err(_) => None,
+        };
         (os_type, desktop_env)
     }
     #[cfg(target_os = "macos")]

--- a/src/useful_tools.rs
+++ b/src/useful_tools.rs
@@ -33,27 +33,40 @@ pub fn determineConfigFolder() -> PathBuf {
 // this function returns operating system and desktop environment(for linux and bsd).
 #[pyfunction]
 pub fn osAndDesktopEnvironment() -> (String, Option<String>) {
+    let mut os_type = String::with_capacity(7);
+    let mut desktop_env: Option<String> = None;
+
     #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
     {
-        let os_type = "Linux".to_string();
-        let desktop_env = match env::var("XDG_CURRENT_DESKTOP") {
+        #[cfg(target_os = "linux")]
+        {
+            os_type.push_str("Linux");
+        }
+
+        #[cfg(target_os = "openbsd")]
+        {
+            os_type.push_str("OpenBSD");
+        }
+
+        #[cfg(target_os = "freebsd")]
+        {
+            os_type.push_str("FreeBSD");
+        }
+
+        desktop_env = match env::var("XDG_CURRENT_DESKTOP") {
             Ok(val) => Some(val),
             Err(_) => None,
         };
-        (os_type, desktop_env)
     }
     #[cfg(target_os = "macos")]
     {
-        let os_type = "Darwin".to_string();
-        let desktop_env = None;
-        (os_type, desktop_env)
+        os_type.push_str("Darwin");
     }
     #[cfg(target_os = "windows")]
     {
-        let os_type = "Windows".to_string();
-        let desktop_env = None;
-        (os_type, desktop_env)
+        os_type.push_str("Windows");
     }
+    (os_type, desktop_env)
 }
 
 // this function converts file_size to KiB or MiB or GiB


### PR DESCRIPTION
## Problem
When i run the app using ` python3 ./test/test.py ` i got some errors:
```
persepolis is running from test folder
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: NotPresent', src/useful_tools.rs:39:64
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Traceback (most recent call last):
  File "/tmp/ghermez/test/test.py", line 40, in <module>
    from persepolis import __main__
  File "/tmp/ghermez/persepolis/__main__.py", line 14, in <module>
    from persepolis.scripts import persepolis
  File "/tmp/ghermez/persepolis/scripts/persepolis.py", line 39, in <module>
    os_type, desktop_env = osAndDesktopEnvironment()
                           ^^^^^^^^^^^^^^^^^^^^^^^^^
pyo3_runtime.PanicException: called `Result::unwrap()` on an `Err` value: NotPresent
```
## Solution
I fixed it [there](https://github.com/javidizadi/ghermez/commit/05c5d813057bb105d4979197d236104ec037cace) by assign "None" to "desktop_env" variable when "XDG_CURRENT_DESKTOP" system environment variable doesn't exists.
